### PR TITLE
Limpando terminal

### DIFF
--- a/src/reversi.cpp
+++ b/src/reversi.cpp
@@ -228,6 +228,8 @@ void Reversi::imprimir_tabuleiro(int jogadorAtual)
 void Reversi::partida()
 {
     int jogadorAtual = 1;
+    limpar_terminal();
+    imprimir_tabuleiro(jogadorAtual);
     std::string mensagemErro;
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 


### PR DESCRIPTION
Alterando uma limpeza de terminal, em tese corrige o erro de ficar imprimindo partes aleatórias do tabuleiro na parte superior da tela